### PR TITLE
added support for .stl export

### DIFF
--- a/cjio/cjio.py
+++ b/cjio/cjio.py
@@ -118,7 +118,7 @@ def info_cmd(context, long):
 @cli.command('export')
 @click.argument('filename')
 @click.option('--format',
-              type=click.Choice(['obj', 'glb', 'b3dm']),
+              type=click.Choice(['obj', 'stl', 'glb', 'b3dm']),
               help="Export format")
 def export_cmd(filename, format):
     """Export the CityJSON to another format.
@@ -139,6 +139,15 @@ def export_cmd(filename, format):
             try:
                 fo = click.open_file(output['path'], mode='w')
                 re = cm.export2obj()
+                # TODO B: why don't you close the file @hugoledoux?
+                fo.write(re.getvalue())
+            except IOError as e:
+                raise click.ClickException('Invalid output file: "%s".\n%s' % (output['path'], e))
+        elif format.lower() == 'stl':
+            utils.print_cmd_status("Exporting CityJSON to STL (%s)" % (output['path']))
+            try:
+                fo = click.open_file(output['path'], mode='w')
+                re = cm.export2stl()
                 # TODO B: why don't you close the file @hugoledoux?
                 fo.write(re.getvalue())
             except IOError as e:

--- a/cjio/cjio.py
+++ b/cjio/cjio.py
@@ -137,19 +137,17 @@ def export_cmd(filename, format):
         if format.lower() == 'obj':
             utils.print_cmd_status("Exporting CityJSON to OBJ (%s)" % (output['path']))
             try:
-                fo = click.open_file(output['path'], mode='w')
-                re = cm.export2obj()
-                # TODO B: why don't you close the file @hugoledoux?
-                fo.write(re.getvalue())
+                with click.open_file(output['path'], mode='w') as fo:
+                    re = cm.export2obj()
+                    fo.write(re.getvalue())
             except IOError as e:
                 raise click.ClickException('Invalid output file: "%s".\n%s' % (output['path'], e))
         elif format.lower() == 'stl':
             utils.print_cmd_status("Exporting CityJSON to STL (%s)" % (output['path']))
             try:
-                fo = click.open_file(output['path'], mode='w')
-                re = cm.export2stl()
-                # TODO B: why don't you close the file @hugoledoux?
-                fo.write(re.getvalue())
+                with click.open_file(output['path'], mode='w') as fo:
+                    re = cm.export2stl()
+                    fo.write(re.getvalue())
             except IOError as e:
                 raise click.ClickException('Invalid output file: "%s".\n%s' % (output['path'], e))
         elif format.lower() == 'glb':

--- a/tests/test_cityjson.py
+++ b/tests/test_cityjson.py
@@ -2,8 +2,11 @@
 
 """
 import pytest
+import os.path
+from click.testing import CliRunner
 import copy
 from cjio import cityjson, models
+from cjio import cjio
 from math import isclose
 
 
@@ -145,3 +148,17 @@ class TestCityJSON:
         cm.reproject(4937) #-- z values should stay the same
         assert isclose(cm.j["vertices"][0][0], 4.36772776578513, abs_tol=0.00001)
         assert (cm.j["metadata"]["geographicalExtent"][5] - cm.j["metadata"]["geographicalExtent"][2]) == 6.1
+
+    def test_convert_to_stl(self, delft):
+         cm = copy.deepcopy(delft)
+         obj = cm.export2stl()
+
+    def test_export_stl_cmd(self, data_dir, data_output_dir):
+        """Debugging"""
+        p = os.path.join(data_dir, 'delft.json')
+        runner = CliRunner()
+        result = runner.invoke(cjio.cli,
+                               args=[p,
+                                     'export',
+                                     '--format', 'stl',
+                                     data_output_dir])


### PR DESCRIPTION
added support for exporting to .stl files.
triangulate_face(..) was slightly changed to return the face normal. Tests are included.

Is it planned to move all export functions to convert.py? 
I have thought about combining export stl and obj in the future and moving them there. 