### PR TITLE
convert f-string to string with format

### DIFF
--- a/cjio/models.py
+++ b/cjio/models.py
@@ -470,7 +470,7 @@ class Geometry(object):
                 for j in range(len(self.boundaries[i])):
                     self.semantics['values'][i].append(None)
         else:
-            raise ValueError(f"{self.type} is not supported at the moment for semantic surfaces")
+            raise ValueError("{} is not supported at the moment for semantic surfaces".format(self.type))
         for i,srf in self.surfaces.items():
             _surface = dict()
             _surface['type'] = srf['type']


### PR DESCRIPTION
I have an issue with Python 3.5 where f-strings cannot be used.

```shell
 /python3.5/site-packages/cjio/models.py", line 473
    raise ValueError(f"{self.type} is not supported at the moment for semantic surfaces")
                                                                                       ^
SyntaxError: invalid syntax
```