### PR TITLE
Fix for extracting the extended LoD-s

### DIFF
--- a/cjio/cityjson.py
+++ b/cjio/cityjson.py
@@ -1689,10 +1689,21 @@ class CityJSON:
 
 
     def extract_lod(self, thelod):
+        def lod_to_string(lod):
+            if lod is None:
+                return None
+            elif isinstance(lod, float):
+                return str(round(lod, 1))
+            elif isinstance(lod, int):
+                return str(lod)
+            elif isinstance(lod, str):
+                return lod
+            else:
+                raise ValueError(f"Type {type(lod)} is not allowed as input")
         for co in self.j["CityObjects"]:
             re = []
             for i, g in enumerate(self.j['CityObjects'][co]['geometry']):
-                if int(g['lod']) != thelod:
+                if lod_to_string(g['lod']) != thelod:
                     re.append(g)  
                     # print (g)      
             for each in re:

--- a/cjio/cjio.py
+++ b/cjio/cjio.py
@@ -561,7 +561,7 @@ def update_textures_cmd(newlocation, relative):
 
 
 @cli.command('extract_lod')
-@click.argument('lod', type=int)
+@click.argument('lod', type=str)
 def extract_lod_cmd(lod):
     """
     Extract only one LoD for a dataset.


### PR DESCRIPTION
Previously integer comparison was used for the LoDs.
Now string comparison is used.

This is a temporary fix until CityJSON 1.1 comes out, and the develop branch is merged.