### PR TITLE
Refactor warnings and CityJSON version checking

### DIFF
--- a/cjio/errors.py
+++ b/cjio/errors.py
@@ -1,7 +1,30 @@
-class InvalidOperation(Exception):
+import warnings
+
+
+class CJInvalidOperation(Exception):
 
     def __init__(self, msg):
         self.msg = msg
 
     def __str__(self):
         return "InvalidOperation: %s" % self.msg
+
+
+class CJInvalidVersion(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __str__(self):
+        return "InvalidVersion: %s" % self.msg
+
+
+class CJWarning(Warning):
+    def __init__(self, msg):
+        super().__init__()
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg
+
+    def warn(self):
+        warnings.warn(self)

--- a/tests/data/dummy/dummy.json
+++ b/tests/data/dummy/dummy.json
@@ -374,6 +374,22 @@
                     }
                 }
             ]
+        },
+        "1243": {
+              "type": "SolitaryVegetationObject",
+              "geometry": [
+                {
+                  "type": "GeometryInstance",
+                  "template": 0,
+                  "boundaries": [0],
+                  "transformationMatrix": [
+                    2.0, 0.0, 0.0, 0.0,
+                    0.0, 2.0, 0.0, 0.0,
+                    0.0, 0.0, 2.0, 0.0,
+                    0.0, 0.0, 0.0, 1.0
+                  ]
+                }
+              ]
         }
     },
     "vertices":

--- a/tests/test_appearances.py
+++ b/tests/test_appearances.py
@@ -51,7 +51,7 @@ def test_update_textures_url(rotterdam_subset):
     assert all(p == npath for p in dirs)
 
 def test_update_textures_none(dummy_noappearance):
-    with pytest.raises(errors.InvalidOperation):
+    with pytest.raises(errors.CJInvalidOperation):
         dummy_noappearance.update_textures_location('somepath', relative=True)
 
 def test_remove_textures(rotterdam_subset):


### PR DESCRIPTION
This PR is a mix of a few related changes.

Three things are refactored:

- The CityJSON version verification is moved to the `CityJSON.check_version` method. This makes it easier to incorporate the cityjson parsing logic into other applications that import cjio.
- Remove the click-dependent `print_cmd_*` warnings from the CityJSON methods and add a new warning system.
- Prefixed the exceptions with `CJ`

The new warning system:
- `errors.CJWarning` is the new warning class https://github.com/cityjson/cjio/compare/develop...check-version?expand=1#diff-0b44b8f893fa10f0f8b8aa24c8353d80d149cbdf9d3d66f40cffbba75b9b5754R21-R30
- issue a warning with `CJWarning(<message>).warn()` eg https://github.com/cityjson/cjio/compare/develop...check-version?expand=1#diff-d44b5fd731b079c54ac6e8593dc2680cbe9f7e83625689f812716f0a39e13961R420
- catch and print the warnings of a function to the CLI from the `cjio` module eg https://github.com/cityjson/cjio/compare/develop...check-version?expand=1#diff-a01c473d7903a68c28ac73071f96eeecc72464a2f1d8269be9502026cd2ebfa0R82-R84
- the `cjio.print_cmd_*` function are extended to also print a list of `warnings.WarningMessage` that are returned from `warnings.catch_warnings(record=True)`

