### PR TITLE
Fix convertion to lat lon

### DIFF
--- a/cjio/cityjson.py
+++ b/cjio/cityjson.py
@@ -1760,7 +1760,7 @@ class CityJSON:
         out.write("endsolid")
         return out
 
-    def reproject(self, epsg):
+    def reproject(self, epsg, digit):
         """
         Project from one CRS to another.
         First the vertices are decompressed and then they are recompressed.
@@ -1777,14 +1777,20 @@ class CityJSON:
         crs_in = CRS(f"EPSG:{self.get_epsg():d}")
         crs_out = CRS(f"EPSG:{epsg:d}")
 
-        if crs_in.is_projected and crs_out.is_geographic:
-            imp_digits = 6
-        elif crs_in.is_geographic and crs_out.is_projected:
-            imp_digits = 3
+        if digit is None:
+            if crs_in.is_projected and crs_out.is_geographic:
+                print("6")
+                imp_digits = 6
+            elif crs_in.is_geographic and crs_out.is_projected:
+                print("3")
+                imp_digits = 3
+            else:
+                imp_digits = math.ceil(abs(
+                    math.log(
+                        self.j["transform"]["scale"][0], 10)))
+                print(imp_digits)
         else:
-            imp_digits = math.ceil(abs(
-                math.log(
-                    self.j["transform"]["scale"][0], 10)))
+            imp_digits = digit
         self.decompress()
         # Using TransformerGroup instead of Transformer, because we cannot retrieve the
         # transformer defintion from it.

--- a/cjio/cityjson.py
+++ b/cjio/cityjson.py
@@ -1,24 +1,25 @@
 
-import os
-import sys
-import re
-import warnings
-
-import json
-import urllib.request
-import math
-import uuid
-import shutil
 import copy
+import json
+import math
+import os
 import random
-from io import StringIO
-import numpy as np
-
-from click import progressbar
+import re
+import shutil
+import sys
+import urllib.request
+import uuid
+import warnings
 from datetime import datetime
+from io import StringIO
 
-from cjio import errors
+import numpy as np
+from click import progressbar
+
+from cjio import convert, errors, geom_help, models, subset
+from cjio.errors import CJInvalidOperation
 from cjio.floatEncoder import FloatEncoder
+from cjio.metadata import generate_metadata
 
 json.encoder.c_make_encoder = None
 json.encoder.float = FloatEncoder
@@ -30,10 +31,9 @@ MODULE_EARCUT_AVAILABLE = True
 MODULE_PANDAS_AVAILABLE = True
 MODULE_CJVAL_AVAILABLE = True
 
-
 try:
-    from pyproj.transformer import TransformerGroup
     from pyproj import CRS
+    from pyproj.transformer import TransformerGroup
 except ImportError as e:
     MODULE_PYPROJ_AVAILABLE = False
 try:
@@ -54,9 +54,6 @@ except ImportError as e:
     MODULE_CJVAL_AVAILABLE = False
 
 
-from cjio import subset, geom_help, convert, models
-from cjio.errors import CJInvalidOperation
-from cjio.metadata import generate_metadata
 
 
 CITYJSON_VERSIONS_SUPPORTED = ['0.6', '0.8', '0.9', '1.0', '1.1', '2.0']

--- a/cjio/cityjson.py
+++ b/cjio/cityjson.py
@@ -16,14 +16,6 @@ from io import StringIO
 import numpy as np
 from click import progressbar
 
-from cjio import convert, errors, geom_help, models, subset
-from cjio.errors import CJInvalidOperation
-from cjio.floatEncoder import FloatEncoder
-from cjio.metadata import generate_metadata
-
-json.encoder.c_make_encoder = None
-json.encoder.float = FloatEncoder
-
 MODULE_NUMPY_AVAILABLE = True
 MODULE_PYPROJ_AVAILABLE = True
 MODULE_TRIANGLE_AVAILABLE = True
@@ -53,6 +45,12 @@ try:
 except ImportError as e:
     MODULE_CJVAL_AVAILABLE = False
 
+MODULE_NUMPY_AVAILABLE = True
+MODULE_PYPROJ_AVAILABLE = True
+MODULE_TRIANGLE_AVAILABLE = True
+MODULE_EARCUT_AVAILABLE = True
+MODULE_PANDAS_AVAILABLE = True
+MODULE_CJVAL_AVAILABLE = True
 
 
 

--- a/cjio/cityjson.py
+++ b/cjio/cityjson.py
@@ -18,6 +18,12 @@ from datetime import datetime
 
 from cjio import errors
 
+class RoundingFloat(float):
+    __repr__ = staticmethod(lambda x: format(x, '.6f'))
+
+json.encoder.c_make_encoder = None
+json.encoder.float = RoundingFloat
+
 MODULE_NUMPY_AVAILABLE = True
 MODULE_PYPROJ_AVAILABLE = True
 MODULE_TRIANGLE_AVAILABLE = True
@@ -1151,6 +1157,7 @@ class CityJSON:
         #-- convert vertices in self.j to int
         n = [0, 0, 0]
         p = '%.' + str(important_digits) + 'f' 
+        print(p)
         for v in self.j["vertices"]:
             for i in range(3):
                 n[i] = v[i] - bbox[i]
@@ -1161,7 +1168,9 @@ class CityJSON:
         ss = '0.'
         ss += '0'*(important_digits - 1)
         ss += '1'
+        print(ss)
         ss = float(ss)
+        print(ss)
         self.j["transform"]["scale"] = [ss, ss, ss]
         self.j["transform"]["translate"] = [bbox[0], bbox[1], bbox[2]]
         #-- clean the file
@@ -1764,6 +1773,7 @@ class CityJSON:
         if not MODULE_PYPROJ_AVAILABLE:
             raise ModuleNotFoundError("Modul 'pyproj' is not available, please install it from https://pypi.org/project/pyproj/")
         imp_digits = math.ceil(abs(math.log(self.j["transform"]["scale"][0], 10)))
+        imp_digits = 6
         self.decompress()
         # Using TransformerGroup instead of Transformer, because we cannot retrieve the
         # transformer defintion from it.
@@ -1771,7 +1781,10 @@ class CityJSON:
         tg = TransformerGroup(f"EPSG:{self.get_epsg():d}",
                               f"EPSG:{epsg:d}",
                               always_xy=True)
-        # TODO: log.info(f"Transformer: {tg.transformers[0].description}")
+        print(f"Transformer: {tg.transformers[0].description}")
+        print(f"Transformer: {tg.transformers[0].accuracy}")
+        print(f"Transformer: {tg.transformers[1].description}")
+        print(f"Transformer: {tg.transformers[1].accuracy}")
         with progressbar(self.j['vertices']) as vertices:
             for v in vertices:
                 x, y, z = tg.transformers[0].transform(v[0], v[1], v[2])
@@ -1782,6 +1795,7 @@ class CityJSON:
         self.update_bbox()
         self.update_bbox_each_cityobjects(False)
         #-- recompress by using the number of digits we had in original file
+        print(f"imp_digits: {imp_digits}")
         self.compress(imp_digits)
 
     def remove_attribute(self, attr):

--- a/cjio/cityjson.py
+++ b/cjio/cityjson.py
@@ -1779,10 +1779,8 @@ class CityJSON:
 
         if digit is None:
             if crs_in.is_projected and crs_out.is_geographic:
-                print("6")
                 imp_digits = 6
             elif crs_in.is_geographic and crs_out.is_projected:
-                print("3")
                 imp_digits = 3
             else:
                 imp_digits = math.ceil(abs(
@@ -1798,6 +1796,7 @@ class CityJSON:
         tg = TransformerGroup(crs_in,
                               crs_out,
                               always_xy=True)
+        tg.download_grids(verbose=True)
 
         with progressbar(self.j['vertices']) as vertices:
             for v in vertices:

--- a/cjio/cityjson.py
+++ b/cjio/cityjson.py
@@ -17,12 +17,10 @@ from click import progressbar
 from datetime import datetime
 
 from cjio import errors
-
-class RoundingFloat(float):
-    __repr__ = staticmethod(lambda x: format(x, '.6f'))
+from cjio.floatEncoder import FloatEncoder
 
 json.encoder.c_make_encoder = None
-json.encoder.float = RoundingFloat
+json.encoder.float = FloatEncoder
 
 MODULE_NUMPY_AVAILABLE = True
 MODULE_PYPROJ_AVAILABLE = True

--- a/cjio/cityjson.py
+++ b/cjio/cityjson.py
@@ -45,27 +45,27 @@ try:
 except ImportError as e:
     MODULE_CJVAL_AVAILABLE = False
 
-MODULE_NUMPY_AVAILABLE = True
-MODULE_PYPROJ_AVAILABLE = True
-MODULE_TRIANGLE_AVAILABLE = True
-MODULE_EARCUT_AVAILABLE = True
-MODULE_PANDAS_AVAILABLE = True
-MODULE_CJVAL_AVAILABLE = True
+from cjio import convert, errors, geom_help, models, subset
+from cjio.errors import CJInvalidOperation
+from cjio.floatEncoder import FloatEncoder
+from cjio.metadata import generate_metadata
 
+json.encoder.c_make_encoder = None
+json.encoder.float = FloatEncoder
 
 
 CITYJSON_VERSIONS_SUPPORTED = ['0.6', '0.8', '0.9', '1.0', '1.1', '2.0']
 
 METADATAEXTENDED_VERSION = "0.6"
 
-CITYJSON_PROPERTIES = ["type", 
-                       "version", 
-                       "extensions", 
-                       "transform", 
-                       "metadata", 
-                       "CityObjects", 
-                       "vertices", 
-                       "appearance", 
+CITYJSON_PROPERTIES = ["type",
+                       "version",
+                       "extensions",
+                       "transform",
+                       "metadata",
+                       "CityObjects",
+                       "vertices",
+                       "appearance",
                        "geometry-templates",
                        "+metadata-extended"
                       ]

--- a/cjio/cjio.py
+++ b/cjio/cjio.py
@@ -10,6 +10,11 @@ import glob
 import cjio
 from cjio import cityjson, utils, errors
 
+class RoundingFloat(float):
+    __repr__ = staticmethod(lambda x: format(x, '.6f'))
+
+json.encoder.c_make_encoder = None
+json.encoder.float = RoundingFloat
 
 #-- https://stackoverflow.com/questions/47437472/in-python-click-how-do-i-see-help-for-subcommands-whose-parents-have-required
 class PerCommandArgWantSubCmdHelp(click.Argument):

--- a/cjio/cjio.py
+++ b/cjio/cjio.py
@@ -469,11 +469,15 @@ def crs_assign_cmd(newepsg):
 
 @cli.command('crs_reproject')
 @click.argument('epsg', type=int)
-def crs_reproject_cmd(epsg):
+@click.option('--digit', type=click.IntRange(1, 12), help='Number of digits to keep.')
+def crs_reproject_cmd(epsg, digit):
     """
     Reproject to a new EPSG.
     The current CityJSON must have an EPSG defined 
     (which can be done with function epsg_assign).
+    It is possible to define the number of digits that will be kept for the result with --digit.
+
+        $ cjio myfile.city.json crs_reproject --digit 7 4979 save newfile.city.json
     """
     def processor(cm):
         if (cityjson.MODULE_PYPROJ_AVAILABLE == False):
@@ -487,14 +491,14 @@ def crs_reproject_cmd(epsg):
             print_cmd_warning("WARNING: CityJSON has no EPSG defined, can't be reprojected.")
         else:
             with warnings.catch_warnings(record=True) as w:
-                cm.reproject(epsg)
+                cm.reproject(epsg, digit)
                 print_cmd_warning(w)
         return cm
     return processor
 
 
 @cli.command('upgrade')
-@click.option('--digit', default=3, type=click.IntRange(1, 12), help='Number of digit to keep to compress.')
+@click.option('--digit', default=3, type=click.IntRange(1, 12), help='Number of digits to keep to compress.')
 def upgrade_cmd(digit):
     """
     Upgrade the CityJSON to the latest version.

--- a/cjio/cjio.py
+++ b/cjio/cjio.py
@@ -9,12 +9,9 @@ import copy
 import glob
 import cjio
 from cjio import cityjson, utils, errors
-
-class RoundingFloat(float):
-    __repr__ = staticmethod(lambda x: format(x, '.6f'))
-
+from cjio.floatEncoder import FloatEncoder
 json.encoder.c_make_encoder = None
-json.encoder.float = RoundingFloat
+json.encoder.float = FloatEncoder
 
 #-- https://stackoverflow.com/questions/47437472/in-python-click-how-do-i-see-help-for-subcommands-whose-parents-have-required
 class PerCommandArgWantSubCmdHelp(click.Argument):

--- a/cjio/floatEncoder.py
+++ b/cjio/floatEncoder.py
@@ -1,0 +1,2 @@
+class FloatEncoder(float):
+    __repr__ = staticmethod(lambda x: format(x, '.6f'))


### PR DESCRIPTION
Fixed the projection from projected to geographic CRS.
There were 2 problems:

1. When a file was reprojected, the same number of important digits was used as in the original file. I fixed this to keep the original number only if both CRS are projected or if both are geographic. Otherwise for geographic I keep 6 important digits and 3 for projected. :
<img width="436" alt="image" src="https://github.com/cityjson/cjio/assets/94386515/a86f9004-5161-45fc-abdf-b1e78877ba27">

2. Even though the scale was float, if we had more that 3 important  digits the json.dumps would convert the float to its scientific form. This would cause the city.json to have the scale in scientific form. I had to tweak the encoder to do that. Found the answer here: https://stackoverflow.com/a/70154903/3709062

This is how a 3DBAG tile looked like when transformed to 4979 before(pink) and after (blue):

<img width="943" alt="image" src="https://github.com/cityjson/cjio/assets/94386515/ee19117e-cdbe-4217-a4f5-2350ff2eb674">

