### PR TITLE
Add early fail for `get_normal_newell` when the provided polygon is too small (< 3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:$PATH"
 RUN pip install maturin
 
-ARG CJVALPY_VERSION="0.3.2"
+ARG CJVALPY_VERSION="0.4.1"
 RUN curl -L -o cjvalpy.tar.gz https://github.com/cityjson/cjvalpy/archive/refs/tags/${CJVALPY_VERSION}.tar.gz && \
     tar -xvf cjvalpy.tar.gz && \
     cd cjvalpy-${CJVALPY_VERSION} && \

--- a/cjio/geom_help.py
+++ b/cjio/geom_help.py
@@ -39,6 +39,8 @@ def get_normal_newell(poly):
         ne = i + 1
         if (ne == len(poly)):
             ne = 0
+        if len(poly[i]) < 3 or len(poly[ne]) < 3:
+            return n, False
         n[0] += ( (poly[i][1] - poly[ne][1]) * (poly[i][2] + poly[ne][2]) )
         n[1] += ( (poly[i][2] - poly[ne][2]) * (poly[i][0] + poly[ne][0]) )
         n[2] += ( (poly[i][0] - poly[ne][0]) * (poly[i][1] + poly[ne][1]) )

--- a/tests/test_geom_help.py
+++ b/tests/test_geom_help.py
@@ -1,0 +1,57 @@
+import typing as t
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from cjio.geom_help import get_normal_newell
+
+
+@pytest.mark.parametrize(
+    ["poly", "expected_normal"],
+    [
+        (
+            [
+                [2195013, 353200, 12283],
+                [2195013, 353200, 8680],
+                [2182302, 347931, 8680],
+                [2182302, 347931, 12159],
+                [2182302, 347931, 12178],
+            ],
+            np.array([-0.38292729, 0.92377848, 0.0]),
+        ),
+        (
+            [
+                [2203406, 332904, 12622],
+                [2203406, 332904, 8680],
+                [2204954, 333543, 8680],
+                [2204954, 333543, 12223],
+                [2204954, 333543, 12584],
+            ],
+            np.array([0.38156054, -0.92434385, 0.0]),
+        ),
+    ],
+)
+def test_get_normal_valid_poly(poly: t.List[t.List[int]], expected_normal: npt.NDArray[t.Any]) -> None:
+    normal, success = get_normal_newell(poly=poly)
+    assert success
+    np.testing.assert_almost_equal(actual=normal, desired=expected_normal)
+
+
+@pytest.mark.parametrize(
+    ["poly", "expected_normal"],
+    [
+        (
+            [[1041, 1009, 1025, 1054, 1087]],
+            np.array([0.0, 0.0, 0.0]),
+        ),
+        (
+            [[[1099, 1098]]],
+            np.array([0.0, 0.0, 0.0]),
+        ),
+    ],
+)
+def test_get_normal_invalid_poly(poly: t.List[t.List[int]], expected_normal: npt.NDArray[t.Any]) -> None:
+    normal, success = get_normal_newell(poly=poly)
+    assert not success
+    np.testing.assert_almost_equal(actual=normal, desired=expected_normal)


### PR DESCRIPTION
Fixes #176 